### PR TITLE
Add Customization toggle to enable Pen Pointer overlay

### DIFF
--- a/app/src/main/java/me/phh/treble/app/Custom.kt
+++ b/app/src/main/java/me/phh/treble/app/Custom.kt
@@ -3,6 +3,7 @@ package me.phh.treble.app
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
+import android.os.SystemProperties
 import android.preference.PreferenceManager
 import java.lang.ref.WeakReference
 
@@ -13,6 +14,11 @@ object Custom: EntryStartup {
         val c = ctxt.get()
         if(c == null) return@OnSharedPreferenceChangeListener
         when(key) {
+            CustomSettings.pointerType -> {
+                val value = sp.getString(key, "mouse")
+                val newValue = if (value == "pen") "true" else "false"
+                SystemProperties.set("persist.sys.overlay.spen_pointer", newValue)
+            }
             CustomSettings.accentColor -> {
                 val value = sp.getString(key, "")
                 val accentColorOverlays = OverlayPicker.getThemeOverlays(OverlayPicker.ThemeOverlay.AccentColor)

--- a/app/src/main/java/me/phh/treble/app/CustomSettings.kt
+++ b/app/src/main/java/me/phh/treble/app/CustomSettings.kt
@@ -9,6 +9,7 @@ object CustomSettings : Settings {
     val iconShape = "key_custom_icon_shape"
     val fontFamily = "key_custom_font_family"
     val iconPack = "key_custom_icon_pack"
+    val pointerType = "key_custom_pointer_type"
 
     override fun enabled() = true
 }

--- a/app/src/main/res/values/pref_custom.xml
+++ b/app/src/main/res/values/pref_custom.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <array name="pref_custom_pointer_type">
+      <item>"Mouse cursor"</item>
+      <item>"Pen pointer"</item>
+    </array>
+    <array name="pref_custom_pointer_type_values">
+      <item>"mouse"</item>
+      <item>"pen"</item>
+    </array>
+
     <array name="pref_custom_accent_color">
 	    <item>"Default"</item>
     </array>

--- a/app/src/main/res/xml/pref_custom.xml
+++ b/app/src/main/res/xml/pref_custom.xml
@@ -7,6 +7,15 @@
             android:targetPackage="com.android.systemui"
             android:targetClass="com.android.systemui.DemoMode" />
     </Preference>
+    <PreferenceCategory android:title="UI">
+		<ListPreference
+		    android:defaultValue="0"
+		    android:entries="@array/pref_custom_pointer_type"
+		    android:entryValues="@array/pref_custom_pointer_type_values"
+		    android:key="key_custom_pointer_type"
+            android:title="Pointer type"
+            android:summary="Requires a reboot" />
+    </PreferenceCategory>
     <PreferenceCategory android:title="Styles">
 	<ListPreference
 		android:defaultValue=""


### PR DESCRIPTION
This enables https://github.com/TrebleDroid/vendor_hardware_overlay/pull/26/commits/20c16c04f634f09e605542152cbddd355b51d3ab