### PR TITLE
Add an option to disable 'ro.telephony.block_binder_thread_on_incoming_calls'

### DIFF
--- a/app/src/main/java/me/phh/treble/app/Misc.kt
+++ b/app/src/main/java/me/phh/treble/app/Misc.kt
@@ -265,6 +265,10 @@ object Misc: EntryStartup {
                     SystemProperties.set("persist.sys.phh.touch_hint", "touch")
                 }
             }
+            MiscSettings.allowBinderThread -> {
+                val value = sp.getBoolean(key, false)
+                SystemProperties.set("persist.sys.phh.allow_binder_thread_on_incoming_calls", if(value) "1" else "0")
+            }
         }
     }
 

--- a/app/src/main/java/me/phh/treble/app/MiscSettings.kt
+++ b/app/src/main/java/me/phh/treble/app/MiscSettings.kt
@@ -39,6 +39,7 @@ object MiscSettings : Settings {
     val restartSystemUI = "key_misc_restart_systemui"
     val fodColor = "key_misc_fod_color"
     val mtkTouchHintIsRotate = "key_misc_mediatek_touch_hint_rotate"
+    val allowBinderThread = "key_misc_allow_binder_thread_on_incoming_calls"
 
     override fun enabled() = true
 }

--- a/app/src/main/res/xml/pref_misc.xml
+++ b/app/src/main/res/xml/pref_misc.xml
@@ -126,6 +126,11 @@
             android:key="key_misc_dynamic_sysbta"
             android:title="Use System Wide BT HAL" />
 		<SwitchPreference
+			android:defaultValue="false"
+			android:key="key_misc_allow_binder_thread_on_incoming_calls"
+			android:summary="Possible workaround for 4G calling\nRequires a reboot"
+			android:title="Allow binder thread on incoming calls" />
+		<SwitchPreference
             android:defaultValue="false"
             android:key="key_misc_force_navbar_off"
             android:title="Force navigation bar disabled"


### PR DESCRIPTION
* It is required to set to false on some devices to fix incoming calls when 4G calling is enabled.
* Tested on Rog Phone 1.