### PR TITLE
feat(nubia): add switch to enable/disable shoulder buttons/triggers

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -63,6 +63,21 @@
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
         </service>
+        <service
+            android:name=".NubiaShoulderBtnTilesService"
+            android:exported="true"
+            android:icon="@drawable/tile_game_mode"
+            android:label="Shoulder triggers"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
+            android:enabled="false">
+            <meta-data
+                android:name="android.service.quicksettings.TOGGLEABLE_TILE"
+                android:value="true" />
+
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
 
         <receiver android:name=".Starter"
             android:exported="true">

--- a/app/src/main/java/me/phh/treble/app/Nubia.kt
+++ b/app/src/main/java/me/phh/treble/app/Nubia.kt
@@ -87,6 +87,23 @@ object Nubia : EntryStartup {
                 val b = sp.getBoolean(key, false)
                 SystemProperties.set("nubia.perf.ufs", if(b) "1" else "0")
             }
+            NubiaSettings.shoulderBtn -> {
+                val i = if(sp.getBoolean(key, false)) "1" else "0"
+                if (NubiaSettings.is6Series()){
+                    // Right
+                    writeToFileNofail("/sys/devices/platform/soc/a88000.i2c/i2c-3/3-0010/mode", i)
+                    // Left
+                    writeToFileNofail("/sys/devices/platform/soc/998000.i2c/i2c-1/1-0010/mode", i)
+                } else if (NubiaSettings.is5GLite()){
+                    // both right and left
+                    writeToFileNofail("/sys/devices/platform/soc/880000.i2c/i2c-0/0-0010/mode", i)
+                } else if (NubiaSettings.is5G5S()){
+                    // Right
+                    writeToFileNofail("/sys/devices/platform/soc/988000.i2c/i2c-1/1-0010/mode", i)
+                    // Left
+                    writeToFileNofail("/sys/devices/platform/soc/990000.i2c/i2c-2/2-0010/mode", i)
+                }
+            }
         }
     }
 
@@ -99,6 +116,7 @@ object Nubia : EntryStartup {
         //Refresh parameters on boot
         spListener.onSharedPreferenceChanged(sp, NubiaSettings.dt2w)
         spListener.onSharedPreferenceChanged(sp, NubiaSettings.tsGameMode)
+        spListener.onSharedPreferenceChanged(sp, NubiaSettings.shoulderBtn)
         spListener.onSharedPreferenceChanged(sp, NubiaSettings.bypassCharger)
         spListener.onSharedPreferenceChanged(sp, NubiaSettings.highTouchScreenSampleRate)
 

--- a/app/src/main/java/me/phh/treble/app/Nubia.kt
+++ b/app/src/main/java/me/phh/treble/app/Nubia.kt
@@ -143,6 +143,14 @@ object Nubia : EntryStartup {
                 ctxt,
                 NubiaGameModeTilesService::class.java
             ), PackageManager.COMPONENT_ENABLED_STATE_ENABLED, 0)
+        if (NubiaSettings.is5G5S() || NubiaSettings.is6Series() || NubiaSettings.is5GLite()) {
+            // Enable shoulder triggers quick setting tile
+            ctxt.packageManager.setComponentEnabledSetting(
+                ComponentName(
+                    ctxt,
+                    NubiaShoulderBtnTilesService::class.java
+                ), PackageManager.COMPONENT_ENABLED_STATE_ENABLED, 0)
 
+        }
     }
 }

--- a/app/src/main/java/me/phh/treble/app/NubiaSettings.kt
+++ b/app/src/main/java/me/phh/treble/app/NubiaSettings.kt
@@ -15,9 +15,12 @@ object NubiaSettings : Settings {
     val boostGpu = "nubia_boost_gpu"
     val boostCache = "nubia_boost_cache"
     val boostUfs = "nubia_boost_ufs"
+    val shoulderBtn = "nubia_shoulder_btn"
 
     override fun enabled() = Tools.vendorFp.toLowerCase().startsWith("nubia/")
     fun is6Series() = Tools.vendorFp.toLowerCase().startsWith("nubia/nx669")
+    fun is5GLite() = Tools.vendorFp.toLowerCase().startsWith("nubia/nx651")
+    fun is5G5S() = Tools.vendorFp.toLowerCase().startsWith("nubia/nx659")
 
 }
 

--- a/app/src/main/java/me/phh/treble/app/NubiaTilesService.kt
+++ b/app/src/main/java/me/phh/treble/app/NubiaTilesService.kt
@@ -124,3 +124,49 @@ class NubiaFanControlTilesService: TileService() {
         super.onTileRemoved()
     }
 }
+
+
+class NubiaShoulderBtnTilesService: TileService() {
+    private lateinit var sp: SharedPreferences
+
+    override fun onCreate() {
+        this.sp = PreferenceManager.getDefaultSharedPreferences(this)
+    }
+
+    // Called when the user adds your tile.
+    override fun onTileAdded() {
+        super.onTileAdded()
+    }
+    // Called when your app can update your tile.
+    override fun onStartListening() {
+        super.onStartListening()
+        val shouldBtnEnabled: Boolean = sp.getBoolean(NubiaSettings.shoulderBtn, false)
+        qsTile.contentDescription = if (shouldBtnEnabled) "On" else "Off"
+        qsTile.state = if (shouldBtnEnabled) Tile.STATE_ACTIVE else Tile.STATE_INACTIVE
+        qsTile.updateTile()
+
+    }
+
+    // Called when your app can no longer update your tile.
+    override fun onStopListening() {
+        super.onStopListening()
+    }
+
+    // Called when the user taps on your tile in an active or inactive state.
+    override fun onClick() {
+        super.onClick()
+        val shouldBtnEnabled: Boolean = sp.getBoolean(NubiaSettings.shoulderBtn, false)
+        with (sp.edit()) {
+            putBoolean(NubiaSettings.shoulderBtn, !shouldBtnEnabled)
+            apply()
+        }
+        qsTile.state = if (shouldBtnEnabled) Tile.STATE_INACTIVE else Tile.STATE_ACTIVE
+        qsTile.contentDescription = if (shouldBtnEnabled) "Off" else "On"
+        qsTile.updateTile()
+    }
+    // Called when the user removes your tile.
+    override fun onTileRemoved() {
+        super.onTileRemoved()
+    }
+
+}

--- a/app/src/main/res/xml/pref_nubia.xml
+++ b/app/src/main/res/xml/pref_nubia.xml
@@ -36,6 +36,13 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:defaultValue="false"
+            android:key="nubia_shoulder_btn"
+            android:title="Enable shoulder buttons"
+            app:summary="Shoulder buttons/triggers" />
+        <CheckBoxPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="false"
             android:key="nubia_bypass_charger"
             android:title="Enable bypass charger"
             app:summaryOff="Charger -> Battery -> Phone"


### PR DESCRIPTION
Add support for shoulder buttons/triggers in nubia 6 series and 5Lite/5G/5S.
This only works after this PR is merged. https://github.com/TrebleDroid/device_phh_treble/pull/41 
Shoulder triggers: 
![image](https://github.com/TrebleDroid/treble_app/assets/38396158/d7654bc1-39eb-46d9-ac78-a7f9d3911137)
