### PR TITLE
feat(nubia): rework gpu boost selector, add missing led mode

### DIFF
--- a/app/src/main/java/me/phh/treble/app/Nubia.kt
+++ b/app/src/main/java/me/phh/treble/app/Nubia.kt
@@ -53,7 +53,11 @@ object Nubia : EntryStartup {
             NubiaSettings.logoBreath -> {
                 val b = sp.getBoolean(key, false)
                 if(b) {
-                    writeToFileNofail("/sys/class/leds/blue/breath_feature", "3 1000 0 700 0 255 3")
+                    if (NubiaSettings.is6Series()) {
+                        writeToFileNofail("/sys/class/leds/red/breath_feature", "2")
+                    } else {
+                        writeToFileNofail("/sys/class/leds/blue/breath_feature", "3 1000 0 700 0 255 3")
+                    }
                 } else {
                     writeToFileNofail("/sys/class/leds/blue/breath_feature", "0")
                     writeToFileNofail("/sys/class/leds/red/breath_feature", "0")
@@ -72,10 +76,10 @@ object Nubia : EntryStartup {
                 SystemProperties.set("nubia.perf.cpu.boost", if(b) "1" else "0")
             }
             NubiaSettings.boostGpu -> {
-                val b = sp.getBoolean(key, false)
-                SystemProperties.set("persist.sys.gpu.boost", if(b) "1" else "0")
-                // 0 - normal, 1 - medium, 2 - maximum
-                SystemProperties.set("nubia.perf.gpu.boost", if(b) "2" else "0")
+                val b = sp.getString(key, "0").toString()
+                SystemProperties.set("persist.sys.gpu.boost", if(b.toInt() >= 1) "1" else "0")
+                // 0 - normal, 1 - medium, 2 - maximum/diablo mode
+                SystemProperties.set("nubia.perf.gpu.boost", b)
             }
 
             NubiaSettings.boostCache -> {

--- a/app/src/main/java/me/phh/treble/app/NubiaAutoFanControlService.kt
+++ b/app/src/main/java/me/phh/treble/app/NubiaAutoFanControlService.kt
@@ -102,7 +102,11 @@ class NubiaAutoFanControlService : Service() {
         }
         val batteryChangedIntent = IntentFilter()
         batteryChangedIntent.addAction(Intent.ACTION_BATTERY_CHANGED)
-        registerReceiver(batteryChangedReceiver, batteryChangedIntent)
+
+        try {
+            registerReceiver(batteryChangedReceiver, batteryChangedIntent)
+        } catch (_: Exception) {
+        }
     }
     private fun stopFan() {
         val gameMode: Boolean = sp.getBoolean(NubiaSettings.tsGameMode, false)
@@ -154,7 +158,7 @@ class NubiaAutoFanControlService : Service() {
 
     private fun isFastCharging(): Boolean {
         val usbType: String = File(usbTypePath).readText(Charsets.UTF_8)
-        val fastChargeUsbTypes = arrayOf("PD", "PD_DRP", "PD_PPS")
-        return fastChargeUsbTypes.contains(usbType)
+        val fastChargeUsbTypes = arrayOf("PD", "DCP", "ACA")
+        return fastChargeUsbTypes.contains("USB_$usbType")
     }
 }

--- a/app/src/main/java/me/phh/treble/app/NubiaSettings.kt
+++ b/app/src/main/java/me/phh/treble/app/NubiaSettings.kt
@@ -12,7 +12,7 @@ object NubiaSettings : Settings {
     val logoBreath = "nubia_redmagic_logo_breath"
     val redmagicLed = "nubia_redmagic_led"
     val boostCpu = "nubia_boost_cpu"
-    val boostGpu = "nubia_boost_gpu"
+    val boostGpu = "nubia_boost_gpu_mode"
     val boostCache = "nubia_boost_cache"
     val boostUfs = "nubia_boost_ufs"
     val shoulderBtn = "nubia_shoulder_btn"

--- a/app/src/main/res/values/pref_nubia.xml
+++ b/app/src/main/res/values/pref_nubia.xml
@@ -15,6 +15,7 @@
 
 	<array name="pref_nubia_redmagic_led">
 		<item>Off</item>
+		<item>On - no effect</item>
 		<item>Scrolling effect 0</item>
 		<item>Scrolling effect 1</item>
 		<item>Scrolling effect 2</item>
@@ -45,6 +46,7 @@
 	</array>
 	<array name="pref_nubia_redmagic_led_values">
 		<item>"0"</item>
+		<item>"1"</item>
 		<item>"0xa0"</item>
 		<item>"0xa1"</item>
 		<item>"0xa2"</item>
@@ -71,5 +73,16 @@
 		<item>"0x86"</item>
 		<item>"0x87"</item>
 		<item>"0x88"</item>
+	</array>
+
+	<array name="pref_nubia_redmagic_gpu_boost">
+		<item>Off</item>
+		<item>Medium</item>
+		<item>Maximum (diablo mode)</item>
+	</array>
+	<array name="pref_nubia_redmagic_gpu_boost_values">
+		<item>"0"</item>
+		<item>"1"</item>
+		<item>"2"</item>
 	</array>
 </resources>

--- a/app/src/main/res/xml/pref_nubia.xml
+++ b/app/src/main/res/xml/pref_nubia.xml
@@ -82,11 +82,11 @@
             android:defaultValue="false"
             android:key="nubia_boost_cache"
             android:title="Boost caches" />
-        <CheckBoxPreference
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:defaultValue="false"
-            android:key="nubia_boost_gpu"
+        <ListPreference
+            android:defaultValue="0"
+            android:entries="@array/pref_nubia_redmagic_gpu_boost"
+            android:entryValues="@array/pref_nubia_redmagic_gpu_boost_values"
+            android:key="nubia_boost_gpu_mode"
             android:title="Boost GPU" />
         <CheckBoxPreference
             android:layout_width="wrap_content"


### PR DESCRIPTION
Note: Changed entry key to `nubia_boost_gpu_mode` for backward compatibility (boolean to string).
Sorry to make another change. The old gpu boost makes the phone overheat without an external cooler. So I added "medium" setting for common users.