### PR TITLE
TranssionSettings: Fix Transsion features not appearing on TECNO Devices

### DIFF
--- a/app/src/main/java/me/phh/treble/app/TranssionSettings.kt
+++ b/app/src/main/java/me/phh/treble/app/TranssionSettings.kt
@@ -6,7 +6,7 @@ object TranssionSettings : Settings {
     val usbOtg = "key_transsion_usb_otg"
     val dt2w = "key_transsion_dt2w"
 
-    override fun enabled() = Tools.vendorFp.startsWith("Infinix/") || Tools.vendorFp.startsWith("Tecno/")
+    override fun enabled() = Tools.vendorFp.startsWith("Infinix/") || Tools.vendorFp.startsWith("TECNO/")
 }
 
 class TranssionSettingsFragment : SettingsFragment() {


### PR DESCRIPTION
This fixes the issue where "Transsion features" only appears on Infinix devices due to the wrong prop detection values for tecno

Should be "TECNO", not "Tecno"