### PR TITLE
Add HIGH_SAMPLING_RATE_SENSORS permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS" />
 
     <uses-permission android:name="android.permission.VIBRATE" />
 


### PR DESCRIPTION
To fix

device fp:Infinix/X693-GL/Infinix-X693:11/RP1A.200720.011/230524V666:user/release-keys product board:Infinix-X693
superior vers:SuperiorOS-Fourteen-arm64_bgS-COMMUNITY-20240304-2103 msg: java.lang.SecurityException: To use the sampling rate of 1000 microseconds, app needs to declare the normal permission HIGH_SAMPLING_RATE_SENSORS. stacktrace: java.lang.SecurityException: To use the sampling rate of 1000 microseconds, app needs to declare the normal permission HIGH_SAMPLING_RATE_SENSORS.
	at android.hardware.SystemSensorManager$BaseEventQueue.enableSensor(SystemSensorManager.java:905)
	at android.hardware.SystemSensorManager$BaseEventQueue.addSensor(SystemSensorManager.java:825)
	at android.hardware.SystemSensorManager.registerListenerImpl(SystemSensorManager.java:275)
	at android.hardware.SensorManager.registerListener(SensorManager.java:855)
	at android.hardware.SensorManager.registerListener(SensorManager.java:762)
	at me.phh.treble.app.Doze$AccelerometerListener.read(Doze.kt:44)
	at me.phh.treble.app.Doze$AccelerometerListener.isFaceUp(Doze.kt:50)
	at me.phh.treble.app.Doze$Pocket.update$lambda$0(Doze.kt:98)
	at me.phh.treble.app.Doze$Pocket.$r8$lambda$jgbQ0-Q9LF-OjDPGkGtUHKEm4gw(Unknown Source:0)
	at me.phh.treble.app.Doze$Pocket$$ExternalSyntheticLambda0.run(Unknown Source:0)
	at android.os.Handler.handleCallback(Handler.java:958)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:205)
	at android.os.Looper.loop(Looper.java:294)
	at android.os.HandlerThread.run(HandlerThread.java:67)