### PR TITLE
Add an option to enable dynamic FPS & Expose TranssionSettings to Itel devices

### DIFF
--- a/app/src/main/java/me/phh/treble/app/Misc.kt
+++ b/app/src/main/java/me/phh/treble/app/Misc.kt
@@ -201,7 +201,7 @@ object Misc: EntryStartup {
             }
             MiscSettings.dynamicFps -> {
                 val value = sp.getBoolean(key, false)
-                SystemProperties.set("persist.sys.phh.dynamic_fps", if (value) "true" else "false")
+                SystemProperties.set("persist.sys.phh.dynamic_fps", if (value) "1" else "0")
             }
             MiscSettings.remotectl -> {
                 val value = sp.getBoolean(key, false)

--- a/app/src/main/java/me/phh/treble/app/Misc.kt
+++ b/app/src/main/java/me/phh/treble/app/Misc.kt
@@ -199,6 +199,10 @@ object Misc: EntryStartup {
                         || (thisMode.getPhysicalHeight() != lastMode.getPhysicalHeight()))
                 }
             }
+            MiscSettings.dynamicFps -> {
+                val value = sp.getBoolean(key, false)
+                SystemProperties.set("persist.sys.phh.dynamic_fps", if (value) "true" else "false")
+            }
             MiscSettings.remotectl -> {
                 val value = sp.getBoolean(key, false)
                 SystemProperties.set("persist.sys.phh.remote", if (value) "true" else "false")

--- a/app/src/main/java/me/phh/treble/app/MiscSettings.kt
+++ b/app/src/main/java/me/phh/treble/app/MiscSettings.kt
@@ -11,6 +11,7 @@ import androidx.preference.Preference
 object MiscSettings : Settings {
     val mobileSignal = "key_misc_mobile_signal"
     val displayFps = "key_misc_display_fps"
+    val dynamicFps = "key_misc_dynamic_fps"
     val maxAspectRatioPreO = "key_misc_max_aspect_ratio_pre_o"
     val multiCameras = "key_misc_multi_camera"
     val forceCamera2APIHAL3 = "key_misc_force_camera2api_hal3"

--- a/app/src/main/java/me/phh/treble/app/TranssionSettings.kt
+++ b/app/src/main/java/me/phh/treble/app/TranssionSettings.kt
@@ -7,6 +7,7 @@ object TranssionSettings : Settings {
     val dt2w = "key_transsion_dt2w"
 
     override fun enabled() = Tools.vendorFp.startsWith("Infinix/") || Tools.vendorFp.startsWith("TECNO/")
+        || Tools.vendorFp.startsWith("Itel/")
 }
 
 class TranssionSettingsFragment : SettingsFragment() {

--- a/app/src/main/res/xml/pref_misc.xml
+++ b/app/src/main/res/xml/pref_misc.xml
@@ -51,6 +51,11 @@
             android:entryValues="@array/pref_misc_display_fps_values"
             android:key="key_misc_display_fps"
             android:title="Force FPS" />
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="key_misc_dynamic_fps"
+            android:title="Dynamic FPS"
+            android:summary="Reduces FPS when idle\nRequires reboot"/>
         <Preference
             android:key="key_misc_restart_systemui"
             android:title="Restart SystemUI"

--- a/app/src/main/res/xml/pref_misc.xml
+++ b/app/src/main/res/xml/pref_misc.xml
@@ -55,7 +55,7 @@
             android:defaultValue="false"
             android:key="key_misc_dynamic_fps"
             android:title="Dynamic FPS"
-            android:summary="Reduces FPS when idle\nRequires reboot"/>
+            android:summary="Adjust refresh rate depending on the content on screen\nRequires reboot"/>
         <Preference
             android:key="key_misc_restart_systemui"
             android:title="Restart SystemUI"


### PR DESCRIPTION
This patch implements a switch to toggle ro.surface_flinger.use_content_detection_for_refresh_rate. Basically what it does is that it will tell SurfaceFlinger to adjust the screen refresh rate based on what's happening on the screen (e.g. if an app does animations that's not demanding, it'll switch the screen refresh rate to 60 Hz and will switch the refresh rate back to normal if something else happens that demand high fps, applies to video playbacks too). This is also great for saving battery consumption on devices with >60Hz screen without compromising UI responsiveness.

Coincidentally, it will also fix an issue where video playbacks will affect SF to render the whole UI as the same frame rate as the video. This bug had been very annoying for me especially when browsing YouTube. With the patch however, it will still do the same but with an exception if something is happening with the UI where it will use the highest frame rate available.