### PR TITLE
Add stylus pen support and re-add d2tw on Y700 2023.

### DIFF
--- a/app/src/main/java/me/phh/treble/app/Lenovo.kt
+++ b/app/src/main/java/me/phh/treble/app/Lenovo.kt
@@ -11,14 +11,34 @@ import java.io.File
 
 object Lenovo: EntryStartup {
     val dtPanel = "/sys/devices/virtual/touch/tp_dev/gesture_on" //K5P
+
+    // DT2W for Y700 (2023)
+    val dtPanel_Y700_2023 = "/proc/gesture_control"
+    // stylus pen support for Y700 (2023)
+    val supportPen_Y700_2023 = "/proc/support_pen"
+
     val spListener = SharedPreferences.OnSharedPreferenceChangeListener { sp, key ->
         when(key) {
             LenovoSettings.dt2w -> {
-                //TODO: We need to check that the screen is on at this time
-                //This won't have any effect if done with screen off
-                val b = sp.getBoolean(key, false)
-                val value = if(b) "1" else "0"
-                writeToFileNofail(dtPanel, value)
+                if (File(Lenovo.dtPanel).exists()) {
+                    //TODO: We need to check that the screen is on at this time
+                    //This won't have any effect if done with screen off
+                    val b = sp.getBoolean(key, false)
+                    val value = if(b) "1" else "0"
+                    writeToFileNofail(dtPanel, value)
+                } else if (File(Lenovo.dtPanel_Y700_2023).exists()) {
+                    val b = sp.getBoolean(key, false)
+                    val value = if(b) "1" else "0"
+                    writeToFileNofail(dtPanel_Y700_2023, value)
+                }
+            }
+            LenovoSettings.support_pen -> {
+                if (File(Lenovo.supportPen_Y700_2023).exists()) {
+                    val b = sp.getBoolean(key, false)
+                    val value = if(b) "1" else "0"
+
+                    writeToFileNofail(supportPen_Y700_2023, value)
+                }
             }
         }
     }
@@ -39,5 +59,6 @@ object Lenovo: EntryStartup {
 
         //Refresh parameters on boot
         spListener.onSharedPreferenceChanged(sp, LenovoSettings.dt2w)
+        spListener.onSharedPreferenceChanged(sp, LenovoSettings.support_pen)
     }
 }

--- a/app/src/main/java/me/phh/treble/app/LenovoSettings.kt
+++ b/app/src/main/java/me/phh/treble/app/LenovoSettings.kt
@@ -4,8 +4,12 @@ import java.io.File
 
 object LenovoSettings : Settings {
     val dt2w = "lenovo_double_tap_to_wake"
+    val support_pen = "lenovo_support_pen"
 
-    override fun enabled() = Tools.vendorFp.contains("Lenovo") && File(Lenovo.dtPanel).exists()
+    override fun enabled(): Boolean {
+        return Tools.vendorFp.contains("Lenovo") &&
+            (File(Lenovo.dtPanel).exists() || File(Lenovo.dtPanel_Y700_2023).exists())
+    }
 }
 
 class LenovoSettingsFragment : SettingsFragment() {

--- a/app/src/main/res/xml/pref_lenovo.xml
+++ b/app/src/main/res/xml/pref_lenovo.xml
@@ -8,5 +8,12 @@
             android:defaultValue="false"
             android:key="lenovo_double_tap_to_wake"
             android:title="Enable DT2W" />
+
+        <SwitchPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="false"
+            android:key="lenovo_support_pen"
+            android:title="Enable Support Stylus Pen" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
This patch adds the stylus pen and d2tw support for the Y700 2023 (TB320FC).
Although d2tw was previously submitted as #32, it seems to have been inadvertently omitted during manual merging.