### PR TITLE
feat: Add Patch SMSC setting to Treble App

### DIFF
--- a/app/src/main/java/me/phh/treble/app/Misc.kt
+++ b/app/src/main/java/me/phh/treble/app/Misc.kt
@@ -242,6 +242,10 @@ object Misc: EntryStartup {
                 val value = sp.getBoolean(key, false)
                 SystemProperties.set("persist.sys.phh.restart_ril", if (value) "true" else "false")
             }
+            MiscSettings.patchSmsc -> {
+                val value = sp.getBoolean(key, true)
+                SystemProperties.set("persist.sys.phh.patch_smsc", if (value) "true" else "false")
+            }
             MiscSettings.minimalBrightness -> {
                 val value = sp.getBoolean(key, false)
                 SystemProperties.set("persist.sys.overlay.minimal_brightness", if (value) "true" else "false")

--- a/app/src/main/java/me/phh/treble/app/MiscSettings.kt
+++ b/app/src/main/java/me/phh/treble/app/MiscSettings.kt
@@ -34,6 +34,7 @@ object MiscSettings : Settings {
     val backlightScale = "key_misc_backlight_scale"
     val headsetDevinput = "key_misc_headset_devinput"
     val restartRil = "key_misc_restart_ril"
+    var patchSmsc = "key_misc_patch_smsc";
     val minimalBrightness = "key_misc_minimal_brightness"
     val aod = "key_misc_aod"
     val dt2w = "key_misc_dt2w"

--- a/app/src/main/res/xml/pref_misc.xml
+++ b/app/src/main/res/xml/pref_misc.xml
@@ -179,6 +179,11 @@
             android:defaultValue="false"
             android:key="key_misc_restart_ril"
             android:title="Automatically restart RIL" />
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="key_misc_patch_smsc"
+            android:title="Patch SMSC"
+            android:summary="Turning this option on or off may fix sending SMS messages on certain Samsung devices/carriers" />
         <Preference android:title="@string/remove_telephony_subsystem"
             android:key="key_misc_removetelephony" />
     </PreferenceCategory>


### PR DESCRIPTION
Requires a personal patch in platform_frameworks_opt_telephony. Primarily intended for Samsung devices. Some require turning this off.
