### PR TITLE
Dual SIM Audio Routing Issue — Temporary Workaround Found

### DIFF
--- a/app/src/main/java/me/phh/treble/app/Samsung.kt
+++ b/app/src/main/java/me/phh/treble/app/Samsung.kt
@@ -14,6 +14,8 @@ import android.telephony.TelephonyManager
 import android.util.Log
 import androidx.annotation.RequiresApi
 import java.io.File
+import android.telephony.SubscriptionManager
+
 
 class Samsung: EntryStartup {
     /*
@@ -100,17 +102,44 @@ class Samsung: EntryStartup {
         }
     }
 
-    val telephonyCallback: TelephonyCallback = @RequiresApi(Build.VERSION_CODES.S)
-    object: TelephonyCallback(), TelephonyCallback.CallStateListener {
-        override fun onCallStateChanged(p0: Int) {
-            Log.d("PHH", "Call state changed $p0")
-            if(p0 == TelephonyManager.CALL_STATE_OFFHOOK) {
-                AudioSystem.setParameters("g_call_state=514") // CALL_STATUS_VOLTE_CP_VOICE_CALL_ON
-            } else {
-                AudioSystem.setParameters("g_call_state=1") // CALL_STATUS_CS_VOICE_CP_VIDEO_CALL_OFF
+@RequiresApi(Build.VERSION_CODES.S)
+val telephonyCallback: TelephonyCallback = object : TelephonyCallback(),
+    TelephonyCallback.CallStateListener,
+    TelephonyCallback.ActiveDataSubscriptionIdListener {
+
+    private var activeSimSlot: Int = 1 // Default SIM slot
+
+    override fun onActiveDataSubscriptionIdChanged(subId: Int) {
+ 
+        val sm = context.getSystemService(SubscriptionManager::class.java)
+        val subscriptionInfoList = sm.activeSubscriptionInfoList
+        for (info in subscriptionInfoList) {
+            if (info.subscriptionId == subId) {
+                activeSimSlot = info.simSlotIndex + 1 // simSlotIndex starts from 0
+                Log.d("PHH", "Detected active SIM slot: $activeSimSlot")
+                break
             }
         }
     }
+
+    override fun onCallStateChanged(state: Int) {
+        Log.d("PHH", "Call state changed $state")
+        try {
+            when (state) {
+                TelephonyManager.CALL_STATE_OFFHOOK -> {
+                    val simSlotHex = "0x%02x".format(activeSimSlot)
+                    AudioSystem.setParameters("g_call_sim_slot=$simSlotHex")
+                    AudioSystem.setParameters("g_call_state=514")
+                }
+                else -> {
+                    AudioSystem.setParameters("g_call_state=1")
+                }
+            }
+        } catch (e: Exception) {
+            Log.e("PHH", "Error handling call state", e)
+        }
+    }
+}
 
     @RequiresApi(Build.VERSION_CODES.S)
     override fun startup(ctxt: Context) {

--- a/app/src/main/java/me/phh/treble/app/Samsung.kt
+++ b/app/src/main/java/me/phh/treble/app/Samsung.kt
@@ -16,7 +16,6 @@ import androidx.annotation.RequiresApi
 import java.io.File
 import android.telephony.SubscriptionManager
 
-
 class Samsung: EntryStartup {
     /*
     Here lies some documentations about stuff that cane be done on Samsung devices:

--- a/app/src/main/java/me/phh/treble/app/Samsung.kt
+++ b/app/src/main/java/me/phh/treble/app/Samsung.kt
@@ -26,6 +26,7 @@ class Samsung: EntryStartup {
         - accesibility: 0 no, 1 negative, 2 color_blind, 3 screen off, 4 grayscale, 5 grayscale_negative, 6 color blind hbm
         - night mode 1 <0-10> (enable and set level) or 0 0 (disable)
      */
+    lateinit var context: Context
     val spListener = SharedPreferences.OnSharedPreferenceChangeListener { sp, key ->
         when(key) {
             SamsungSettings.highBrightess -> {
@@ -142,6 +143,7 @@ val telephonyCallback: TelephonyCallback = object : TelephonyCallback(),
 
     @RequiresApi(Build.VERSION_CODES.S)
     override fun startup(ctxt: Context) {
+        context = ctxt
         if (!SamsungSettings.enabled()) return
 
         val handler = Handler(HandlerThread("SamsungThread").apply { start()}.looper)


### PR DESCRIPTION
**Devices:**
- Samsung Galaxy M11 (SDM450)
- Samsung Galaxy A11 (SDM450)
- Samsung Galaxy A20s (SDM450)
- --------------------------------------------------------------
###  Expected Behavior (Single SIM Mode)
- Inserting a SIM in slot 1 or slot 2: audio works fine during calls.

---

###  Bug (Dual SIM Mode)
- When both SIMs are inserted:
  - Only one SIM (usually the one with data enabled) has working audio.
  - The second SIM has no audio during calls.
  - Switching call to that SIM results in silence (no mic/no speaker audio).

---

###  Workaround
- Temporarily enable mobile data on the affected SIM **before or during the call**, then disable it again.
- This reinitializes audio routing and makes audio work normally.
- We tested and confirmed this behavior multiple times.

---

###  Notes
- Before patching, **audio only worked on SIM1**.
- After implementing logic to handle `g_call_sim_slot`, `g_call_state` and binding them to the **active data subscription**, audio started working on both SIMs — **but still requires toggling data**.

------
###  Suggestion
Please consider applying this logic in official builds:
- When call starts, auto-switch data briefly to the call SIM to initialize audio path (then revert back after a short delay or after the call ends).
- Or improve internal audio routing behavior based on active call SIM instead of active data SIM.