### PR TITLE
Bluetooth audio fix for Lenovo Y700 gen4 (TB322FC). [1/3]

### DIFF
--- a/app/src/main/java/me/phh/treble/app/LenovoSettings.kt
+++ b/app/src/main/java/me/phh/treble/app/LenovoSettings.kt
@@ -10,6 +10,10 @@ object LenovoSettings : Settings {
         return Tools.vendorFp.contains("Lenovo") &&
             (File(Lenovo.dtPanel).exists() || File(Lenovo.dtPanel_Y700_2023).exists())
     }
+
+    fun bluetooth_fix(): Boolean {
+        return Tools.vendorFp.startsWith("Lenovo/TB322FC")
+    }
 }
 
 class LenovoSettingsFragment : SettingsFragment() {

--- a/app/src/main/java/me/phh/treble/app/Misc.kt
+++ b/app/src/main/java/me/phh/treble/app/Misc.kt
@@ -221,6 +221,10 @@ object Misc: EntryStartup {
                 val value = sp.getBoolean(key, false)
                 SystemProperties.set("persist.bluetooth.system_audio_hal.enabled", if (value) "true" else "false")
             }
+            MiscSettings.a2dp_offload -> {
+                val value = sp.getBoolean(key, false)
+                SystemProperties.set("persist.bluetooth.enable_bt_offload", if (value) "true" else "false")
+            }
             MiscSettings.noHwcomposer -> {
                 val value = sp.getBoolean(key, false)
                 enableHwcOverlay(!value)
@@ -367,7 +371,16 @@ object Misc: EntryStartup {
         spListener.onSharedPreferenceChanged(sp, MiscSettings.forceCamera2APIHAL3)
         if (! sp.contains(MiscSettings.headsetFix))
             sp.edit().putBoolean(MiscSettings.headsetFix, HuaweiSettings.enabled()).commit()
-        sp.edit().putBoolean(MiscSettings.sysbta, SystemProperties.getBoolean("persist.bluetooth.system_audio_hal.enabled", false)).apply()
+        if (LenovoSettings.bluetooth_fix() && ! sp.contains(MiscSettings.sysbta)) {
+            // Y700 gen4 and first time boot
+            Log.i("PHH", "Applying bluetooth fix")
+            sp.edit().putBoolean(MiscSettings.sysbta, false).apply()
+            sp.edit().putBoolean(MiscSettings.a2dp_offload, true).apply()
+        } else {
+            Log.i("PHH", "Don't apply bluetooth fix")
+            sp.edit().putBoolean(MiscSettings.sysbta, SystemProperties.getBoolean("persist.bluetooth.system_audio_hal.enabled", false)).apply()
+            sp.edit().putBoolean(MiscSettings.a2dp_offload, SystemProperties.getBoolean("persist.bluetooth.enable_bt_offload", false)).apply()
+        }
         spListener.onSharedPreferenceChanged(sp, MiscSettings.headsetFix)
         spListener.onSharedPreferenceChanged(sp, MiscSettings.bluetooth)
         spListener.onSharedPreferenceChanged(sp, MiscSettings.displayFps)

--- a/app/src/main/java/me/phh/treble/app/MiscSettings.kt
+++ b/app/src/main/java/me/phh/treble/app/MiscSettings.kt
@@ -29,6 +29,7 @@ object MiscSettings : Settings {
     val disableFastAudio = "key_misc_disable_fast_audio"
     val cameraTimestampOverride = "key_misc_camera_timestamp"
     val sysbta = "key_misc_dynamic_sysbta"
+    val a2dp_offload = "key_misc_a2dp_offload"
     val noHwcomposer = "key_misc_no_hwcomposer"
     val storageFUSE = "key_misc_storage_fuse"
     val backlightScale = "key_misc_backlight_scale"

--- a/app/src/main/res/xml/pref_misc.xml
+++ b/app/src/main/res/xml/pref_misc.xml
@@ -146,6 +146,11 @@
             android:defaultValue="true"
             android:key="key_misc_dynamic_sysbta"
             android:title="Use System Wide BT HAL" />
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="key_misc_a2dp_offload"
+            android:title="Enable A2DP Offload"
+            android:summary="Only effective if System Wide BT HAL is disabled" />
         <ListPreference
             android:defaultValue="0"
             android:entries="@array/pref_misc_bluetooth"


### PR DESCRIPTION
This is a part of patch series to fix bluetooth audio Lenovo Y700 gen4 (TB322FC).

The device currently doesn't work with sysbta and disabled offload. This commit adds a new setting called a2dp_offload to enable bluetooth a2dp offload on TB322FC.
On the first time boot, it detects device and then disables sysbta and enables offload.

Close https://github.com/TrebleDroid/treble_experimentations/issues/219#issuecomment-3607344205

The following two PRs are also required.
https://github.com/TrebleDroid/device_phh_treble/pull/83
https://github.com/TrebleDroid/platform_packages_modules_Bluetooth/pull/3